### PR TITLE
canvasToTempFilePath add usingIn

### DIFF
--- a/utils/weapp-qrcode.js
+++ b/utils/weapp-qrcode.js
@@ -416,7 +416,7 @@ var QRCode;
             success: (res) => {
               this._htOption.callback({path: res.tempFilePath})
             }
-        })
+        }, this._htOption.usingIn)
       } 
     }
 


### PR DESCRIPTION
在 组件中 调用 canvasToTempFilePath 时，也需要传入初始化时的 this 属性。

否则会报错：{errMsg: "canvasToTempFilePath: fail canvas is empty"}